### PR TITLE
Fix shopping handler factory

### DIFF
--- a/src/a2a/controller.py
+++ b/src/a2a/controller.py
@@ -68,10 +68,11 @@ def create_http_server(host: str, port: int, service: ShoppingService | None = N
     if service is None:
         handler_cls = ShoppingRequestHandler
     else:
-        class CustomShoppingHandler(ShoppingRequestHandler):
-            service = service
-
-        handler_cls = CustomShoppingHandler
+        handler_cls = type(
+            "CustomShoppingHandler",
+            (ShoppingRequestHandler,),
+            {"service": service},
+        )
 
     return ThreadingHTTPServer((host, port), handler_cls)
 

--- a/src/utils/urls.py
+++ b/src/utils/urls.py
@@ -1,0 +1,31 @@
+"""Centralised URL definitions for service endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MCPURLs:
+    """URL mapping for the MCP tool microservice."""
+
+    list_tools: str = "/v1/tools"
+    tool_invoke: str = "/v1/tools/{tool_name}:invoke"
+    tool_invoke_prefix: str = "/v1/tools/"
+    tool_invoke_suffix: str = ":invoke"
+    websocket: str = "/ws/tools"
+    health: str = "/healthz"
+
+
+@dataclass(frozen=True)
+class ShoppingURLs:
+    """URL mapping for the shopping session orchestrator."""
+
+    health: str = "/healthz"
+    sessions: str = "/v1/sessions"
+
+
+MCP_URLS = MCPURLs()
+SHOPPING_URLS = ShoppingURLs()
+
+__all__ = ["MCP_URLS", "SHOPPING_URLS", "MCPURLs", "ShoppingURLs"]


### PR DESCRIPTION
## Summary
- adjust the shopping HTTP handler factory to build a subclass via `type` when injecting a custom service so the closure does not shadow the outer variable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef260d68c832c9ec98bb9a284de2b