### PR TITLE
Connect merchant agent MCP toolset over HTTP

### DIFF
--- a/src/merchant_agent/__init__.py
+++ b/src/merchant_agent/__init__.py
@@ -1,7 +1,0 @@
-"""Merchant agent package exposing LLM and rule-based implementations."""
-
-__all__ = [
-    "agent",
-    "rule_based",
-    "mcp_client",
-]

--- a/src/merchant_agent/agent.py
+++ b/src/merchant_agent/agent.py
@@ -1,46 +1,144 @@
-import sys
+"""Merchant agent definitions that integrate with a remote MCP service."""
 
-from mcp import StdioServerParameters
+from __future__ import annotations
 
-from google.adk.tools import MCPToolset
-from google.adk.tools.mcp_tool import StdioConnectionParams
-from google.adk.agents import Agent, LlmAgent
-from google.adk.models.lite_llm import LiteLlm
+import inspect
+import os
+from typing import TYPE_CHECKING, Any, Callable
+from urllib.parse import urlparse, urlunparse
 
-from config import *
-from my_mcp import PATH_TO_MCP_SERVER
+from config import MODEL_NAME, OPENAI_API_BASE, OPENAI_API_KEY
 
-with open("src/merchant_agent/instruction.txt", "r") as f:
+try:  # pragma: no cover - optional dependency handling
+    from google.adk.tools import MCPToolset as _GoogleMCPToolset
+except ImportError:  # pragma: no cover - exercised implicitly in tests
+    _GoogleMCPToolset = None
+
+try:  # pragma: no cover - optional dependency handling
+    from google.adk.tools.mcp_tool import StreamableHTTPConnectionParams as _StreamableHTTPConnectionParams
+except ImportError:  # pragma: no cover - exercised implicitly in tests
+    _StreamableHTTPConnectionParams = None
+
+try:  # pragma: no cover - optional dependency handling
+    from google.adk.tools.mcp_tool import HttpConnectionParams as _HttpConnectionParams
+except ImportError:  # pragma: no cover - exercised implicitly in tests
+    _HttpConnectionParams = None
+
+try:  # pragma: no cover - optional dependency handling
+    from google.adk.agents import Agent as _GoogleAgent, LlmAgent as _GoogleLlmAgent
+except ImportError:  # pragma: no cover - exercised implicitly in tests
+    _GoogleAgent = None
+    _GoogleLlmAgent = None
+
+try:  # pragma: no cover - optional dependency handling
+    from google.adk.models.lite_llm import LiteLlm as _GoogleLiteLlm
+except ImportError:  # pragma: no cover - exercised implicitly in tests
+    _GoogleLiteLlm = None
+
+if TYPE_CHECKING:  # pragma: no cover - type-checking only
+    from google.adk.agents import Agent, LlmAgent
+    from google.adk.models.lite_llm import LiteLlm
+    from google.adk.tools import MCPToolset
+
+_MCP_SERVICE_URL_ENV = "MCP_SERVICE_URL"
+_DEFAULT_MCP_SERVICE_URL = "http://localhost:8000"
+
+with open("src/merchant_agent/instruction.txt", "r", encoding="utf-8") as f:
     _INSTRUCTION = f.read().strip()
+
 _DESCRIPTION = "Salesperson who helps Customers to find products, calculate shipping costs and reserve stock."
 
 
-def get_mcp_toolset() -> MCPToolset:
-    """Get MCP Toolset"""
-    py_cmd = sys.executable or ("python3" if os.name != "nt" else "python")
+def _require(name: str, value: Any) -> Any:
+    """Ensure optional Google ADK components are available before use."""
 
-    if not PATH_TO_MCP_SERVER.exists():
-        raise FileNotFoundError(f"MCP server script not found: {PATH_TO_MCP_SERVER}")
-
-    # env = os.environ.copy()
-    cwd = str(PATH_TO_MCP_SERVER.parent)
-
-    return MCPToolset(
-        connection_params=StdioConnectionParams(
-            server_params=StdioServerParameters(
-                command=py_cmd,
-                args=[str(PATH_TO_MCP_SERVER)],
-                # env=env,
-                cwd=cwd,
-                # startup_timeout_seconds=15,
-                # healthcheck_command=None,  # hoặc ["python","-V"] nếu SDK hỗ trợ
-            )
+    if value is None:
+        raise RuntimeError(
+            "google-adk is required to instantiate merchant agents with MCP tooling; "
+            f"missing component: {name}."
         )
+    return value
+
+
+def _resolve_http_connection_class() -> Callable[..., Any]:
+    """Return the first available HTTP connection parameter class."""
+
+    for candidate, name in (
+        (_StreamableHTTPConnectionParams, "StreamableHTTPConnectionParams"),
+        (_HttpConnectionParams, "HttpConnectionParams"),
+    ):
+        if candidate is not None:
+            return candidate
+    raise RuntimeError(
+        "google-adk does not provide HTTP MCP connection parameters. "
+        "Install a version that supports StreamableHTTP transports."
     )
 
 
-def gemini_merchant_agent() -> Agent:
-    return Agent(
+def _normalise_service_url(raw_url: str | None) -> str:
+    """Normalise the MCP service URL and validate its scheme."""
+
+    candidate = (raw_url or _DEFAULT_MCP_SERVICE_URL).strip()
+    parsed = urlparse(candidate)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(
+            "MCP service URL must use http or https scheme: "
+            f"{candidate!r}"
+        )
+    if not parsed.netloc:
+        raise ValueError(f"MCP service URL is missing host information: {candidate!r}")
+
+    path = parsed.path.rstrip("/")
+    normalised = urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
+    return normalised
+
+
+def _build_websocket_url(http_url: str) -> str:
+    """Derive a WebSocket URL from the HTTP endpoint if required."""
+
+    parsed = urlparse(http_url)
+    ws_scheme = "wss" if parsed.scheme == "https" else "ws"
+    return urlunparse((ws_scheme, parsed.netloc, parsed.path, "", "", ""))
+
+
+def _create_http_connection_params(service_url: str) -> Any:
+    """Instantiate the ADK connection parameter object for HTTP transport."""
+
+    connection_cls = _resolve_http_connection_class()
+    signature = inspect.signature(connection_cls)
+    kwargs: dict[str, Any] = {}
+
+    for option in ("url", "endpoint", "base_url", "uri"):
+        if option in signature.parameters:
+            kwargs[option] = service_url
+            break
+    else:  # pragma: no cover - depends on external library implementation
+        raise RuntimeError(
+            "Unsupported google-adk HTTP connection parameter signature; cannot determine URL argument."
+        )
+
+    for ws_option in ("websocket_url", "ws_url"):
+        parameter = signature.parameters.get(ws_option)
+        if parameter is not None and parameter.default is inspect._empty:
+            kwargs[ws_option] = _build_websocket_url(service_url)
+
+    return connection_cls(**kwargs)
+
+
+def get_mcp_toolset() -> "MCPToolset":
+    """Create an MCP toolset that connects to a remote HTTP MCP server."""
+
+    toolset_cls = _require("MCPToolset", _GoogleMCPToolset)
+    service_url = _normalise_service_url(os.environ.get(_MCP_SERVICE_URL_ENV))
+    connection_params = _create_http_connection_params(service_url)
+    return toolset_cls(connection_params=connection_params)
+
+
+def gemini_merchant_agent() -> "Agent":
+    """Instantiate the Gemini-based merchant agent configured for remote MCP."""
+
+    agent_cls = _require("Agent", _GoogleAgent)
+    return agent_cls(
         name="merchant_agent",
         model="gemini-2.0-flash",
         description=_DESCRIPTION,
@@ -49,10 +147,14 @@ def gemini_merchant_agent() -> Agent:
     )
 
 
-def llm_merchant_agent() -> LlmAgent:
-    return LlmAgent(
+def llm_merchant_agent() -> "LlmAgent":
+    """Instantiate the OpenAI-compatible merchant agent configured for remote MCP."""
+
+    agent_cls = _require("LlmAgent", _GoogleLlmAgent)
+    lite_llm_cls = _require("LiteLlm", _GoogleLiteLlm)
+    return agent_cls(
         name="merchant_agent",
-        model=LiteLlm(
+        model=lite_llm_cls(
             model=MODEL_NAME,
             api_base=OPENAI_API_KEY,
             api_key=OPENAI_API_BASE,
@@ -63,4 +165,7 @@ def llm_merchant_agent() -> LlmAgent:
     )
 
 
-root_agent = gemini_merchant_agent()
+try:  # pragma: no cover - graceful failure when google-adk is absent
+    root_agent = gemini_merchant_agent()
+except RuntimeError:  # pragma: no cover - exercised implicitly in tests
+    root_agent = None


### PR DESCRIPTION
## Summary
- update the merchant agent to obtain its MCP tools through the HTTP transport so it can call a remote server
- normalise the MCP service URL, build the appropriate connection parameters, and provide clear errors when google-adk is missing
- remove the unused merchant_agent package initializer to reduce clutter in the module directory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfacb3c1f0832cace01c76968e1937